### PR TITLE
Period between Classification Results

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-11-11T18:48:31.891851600Z">
+        <DropdownSelection timestamp="2024-11-12T20:14:37.108542600Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=RF8N908MQLJ" />

--- a/app/src/main/java/com/example/activityapp/MLclassification/ActivityClassifier.kt
+++ b/app/src/main/java/com/example/activityapp/MLclassification/ActivityClassifier.kt
@@ -5,6 +5,7 @@ import org.tensorflow.lite.Interpreter
 import java.io.FileInputStream
 import java.nio.MappedByteBuffer
 import java.nio.channels.FileChannel
+import android.util.Log
 
 class ActivityClassifier(context: Context, private val windowSize: Int = 250) { /// CHANGE WINDOW SIZE
     // Loads activity_model.tflite and performs inference
@@ -41,14 +42,17 @@ class ActivityClassifier(context: Context, private val windowSize: Int = 250) { 
         // Adds the new accelerometer data (x, y and z) to the buffer as a Float array containing these values.
         // Adds a single set of three values (x, y and z) to the buffer
         buffer.add(floatArrayOf(x, y, z))
+        Log.d("ActivityClassifier", "Buffer size is ${buffer.size}")
         // Check if buffer has reached or exceeded the specified windowSize
         // WindowSize defines how many data points are needed before classification can occur
         if (buffer.size == windowSize) {
             // classify() function called and returns a String representing and activity
             val result = classify()
+            Log.d("ActivityClassifier", "Buffer size ${buffer.size} is now the same as window size ${windowSize}. Making classification")
             // Removes the oldest data point from buffer to keep the list size constant
             // Could reduce computational load by increasing the number of data points removed
-            buffer.removeAt(0)  // Keep buffer size constant
+            buffer.subList(0, 25).clear() // Determine how often a classification should be made
+            Log.d("ActivityClassifier", "Removing elements from buffer, buffer size is now ${buffer.size}")
             // Return the classification result.
             return result
         }

--- a/app/src/main/java/com/example/activityapp/MLclassification/ActivityClassifier.kt
+++ b/app/src/main/java/com/example/activityapp/MLclassification/ActivityClassifier.kt
@@ -13,6 +13,11 @@ class ActivityClassifier(context: Context, private val windowSize: Int = 250) { 
     // Creates empty list of FloatArray elements. Each FloatArray element holds the x, y and z values of sensor readings
     private val buffer = mutableListOf<FloatArray>()
 
+    // Define period (seconds) between classification results
+    private val classification_period = 1
+    // This will be the amount of buffer readings removed after every classification is made
+    private val bufferReadingsToRemove = classification_period * 25
+
     init {
         try {
             val modelFile = loadModelFile(context.assets, "activity_model_2.tflite")
@@ -51,7 +56,7 @@ class ActivityClassifier(context: Context, private val windowSize: Int = 250) { 
             Log.d("ActivityClassifier", "Buffer size ${buffer.size} is now the same as window size ${windowSize}. Making classification")
             // Removes the oldest data point from buffer to keep the list size constant
             // Could reduce computational load by increasing the number of data points removed
-            buffer.subList(0, 25).clear() // Determine how often a classification should be made
+            buffer.subList(0, bufferReadingsToRemove).clear() // Determine how often a classification should be made
             Log.d("ActivityClassifier", "Removing elements from buffer, buffer size is now ${buffer.size}")
             // Return the classification result.
             return result

--- a/app/src/main/java/com/example/activityapp/MLclassification/SocialSignalClassifier.kt
+++ b/app/src/main/java/com/example/activityapp/MLclassification/SocialSignalClassifier.kt
@@ -10,6 +10,11 @@ class SocialSignalClassifier(context: Context, private val windowSize: Int = 200
     private val interpreter: Interpreter
     private val buffer = mutableListOf<FloatArray>()
 
+    // Define period (seconds) between classification results
+    private val classification_period = 1
+    // This will be the amount of buffer readings removed after every classification is made
+    private val bufferReadingsToRemove = classification_period * 25
+
     init {
         val modelFile = loadModelFile(context.assets, "social_signal_model_2.tflite")
         interpreter = Interpreter(modelFile)
@@ -26,7 +31,7 @@ class SocialSignalClassifier(context: Context, private val windowSize: Int = 200
         buffer.add(floatArrayOf(x, y, z))
         if (buffer.size == windowSize) {
             val result = classify()
-            buffer.subList(0, 25).clear()  // Determine how often a classification should be made
+            buffer.subList(0, bufferReadingsToRemove).clear()  // Determine how often a classification should be made
             return result
         }
         return null

--- a/app/src/main/java/com/example/activityapp/MLclassification/SocialSignalClassifier.kt
+++ b/app/src/main/java/com/example/activityapp/MLclassification/SocialSignalClassifier.kt
@@ -26,7 +26,7 @@ class SocialSignalClassifier(context: Context, private val windowSize: Int = 200
         buffer.add(floatArrayOf(x, y, z))
         if (buffer.size == windowSize) {
             val result = classify()
-            buffer.removeAt(0)  // Keep buffer size constant
+            buffer.subList(0, 25).clear()  // Determine how often a classification should be made
             return result
         }
         return null

--- a/app/src/main/java/com/example/activityapp/live/LiveDataActivity.kt
+++ b/app/src/main/java/com/example/activityapp/live/LiveDataActivity.kt
@@ -66,6 +66,10 @@ class LiveDataActivity : AppCompatActivity() {
     private lateinit var activityClassifier: ActivityClassifier
     private lateinit var socialSignalClassifier: SocialSignalClassifier
 
+    // For storing latest classification results
+    private var lastActivity: String? = null
+    private var lastSocialSignal: String? = null
+
     // Initialises UI elements, chart of live data and classifiers
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -78,6 +82,13 @@ class LiveDataActivity : AppCompatActivity() {
 
 
         setupCharts()
+
+        // Set initial classification results to "Processing"
+        val activityTextView: TextView = findViewById(R.id.activity_classification)
+        activityTextView.text = "Processing..."
+
+        val socialSignalTextView: TextView = findViewById(R.id.social_signal_classification)
+        socialSignalTextView.text = "Processing..."
 
         // set up the broadcast receiver
         respeckLiveUpdateReceiver = object : BroadcastReceiver() {
@@ -108,19 +119,24 @@ class LiveDataActivity : AppCompatActivity() {
                     //ADDED FOR ML
                     // Classify activity. Will be null until the buffer fills up
                     val activity = activityClassifier.addSensorData(x, y, z)
+                    // Update the latest classification result if it is different to the last one
+                    if (activity != null && activity != lastActivity) {
+                        lastActivity = activity
+                        runOnUiThread{
+                            val activityTextView: TextView = findViewById(R.id.activity_classification)
+                            activityTextView.text = activity
+                        }
+                    }
 
                     // Classify social signal. Will be null until buffer fills up
                     val socialSignal = socialSignalClassifier.addSensorData(x, y, z)
-
-                    runOnUiThread {
-                        // Update Activity Classification TextView in layout.xml
-                        val activityTextView: TextView = findViewById(R.id.activity_classification)
-                        // If activity is not full, activityTextView.text will show the classification label
-                        activityTextView.text = activity ?: "Processing..."
-
-                        // Update Social Signal Classification TextView
-                        val socialSignalTextView: TextView = findViewById(R.id.social_signal_classification)
-                        socialSignalTextView.text = socialSignal ?: "Processing..."
+                    // Update the latest classification result if it is different to the last one
+                    if (socialSignal != null && socialSignal != lastSocialSignal) {
+                        lastSocialSignal = socialSignal
+                        runOnUiThread{
+                            val socialSignalTextView: TextView = findViewById(R.id.social_signal_classification)
+                            socialSignalTextView.text = socialSignal
+                        }
                     }
                 }
             }


### PR DESCRIPTION
These changes fix the flickering output issue. We can define how often we want a classification result to be produced from either model.
*  In `ActivityClassifier.kt` and `SocialSignalClassifier.kt`, the `classification_period` (i.e. time between classification results) in seconds can be defined, for example 2.
* This value is then multiplied by 25 to get the total number of readings, for example 2 x 25 = 50 readings.
* Overview:
  * So at first the buffer is empty, and fills up to the window_size, for example 250. While the buffer is doing this initial filling up, "Processing..." is displayed in the app.
  * When the buffer reaches the window size, it makes a classification (`classify()`), as in the `addSensorData` function.
  * After this, the buffer clears the x oldest readings from the buffer (in this example, x is 50).
  * The buffer then has 200 readings in it, and begins filling up to 250 again. This will take 2 seconds, as defined above in `classification_period`. It is 2 seconds because each second, 25 readings enter the buffer.
  * When the buffer reaches 250, the cycle repeats.